### PR TITLE
fix: harden credential persistence

### DIFF
--- a/apps/electron/src/main/credentialStore.test.ts
+++ b/apps/electron/src/main/credentialStore.test.ts
@@ -1,16 +1,18 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
 // safeStorage is unavailable outside Electron; encrypt/decrypt through a
 // deterministic stand-in so the round-trip contract is still exercised.
+let encryptionAvailable = true;
+
 mock.module('electron', () => ({
   app: {
     getPath: () => '/tmp/finagent-test',
   },
   safeStorage: {
-    isEncryptionAvailable: () => true,
+    isEncryptionAvailable: () => encryptionAvailable,
     encryptString: (value: string) =>
       Buffer.from(`enc:${Buffer.from(value, 'utf8').toString('base64')}`, 'utf8'),
     decryptString: (buffer: Buffer) =>
@@ -31,6 +33,7 @@ let dir = '';
 let file = '';
 
 beforeEach(async () => {
+  encryptionAvailable = true;
   dir = await mkdtemp(join(tmpdir(), 'credstore-'));
   file = join(dir, 'credentials.json');
 });
@@ -62,6 +65,7 @@ describe('CredentialStore', () => {
 
     const infos = await store.listCredentials();
     expect(infos.find((info) => info.provider === 'anthropic')?.configured).toBe(true);
+    expect(infos.find((info) => info.provider === 'anthropic')?.updatedAt).toBeNumber();
   });
 
   it('removes credentials', async () => {
@@ -102,5 +106,39 @@ describe('CredentialStore', () => {
 
     const reloaded = new CredentialStore(file);
     expect(await reloaded.getCredential('anthropic')).toBe('sk-persisted-999');
+  });
+
+  it('refuses to persist credentials when secure storage is unavailable', async () => {
+    encryptionAvailable = false;
+    const store = new CredentialStore(file);
+
+    await expect(store.setCredential('anthropic', 'sk-must-not-hit-disk')).rejects.toThrow(
+      'Secure credential storage is unavailable'
+    );
+    await expect(readFile(file, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('preserves the previous file and cache when an atomic write fails', async () => {
+    const store = new CredentialStore(file);
+    await store.setCredential('anthropic', 'sk-original-value');
+    const original = await readFile(file, 'utf8');
+    await mkdir(`${file}.tmp`);
+
+    await expect(store.setCredential('openai', 'sk-new-value')).rejects.toBeDefined();
+    expect(await readFile(file, 'utf8')).toBe(original);
+    expect(await store.getCredential('openai')).toBeUndefined();
+    expect(await store.getCredential('anthropic')).toBe('sk-original-value');
+  });
+
+  it('serializes concurrent credential updates without losing either value', async () => {
+    const store = new CredentialStore(file);
+    await Promise.all([
+      store.setCredential('anthropic', 'sk-anthropic-concurrent'),
+      store.setCredential('openai', 'sk-openai-concurrent'),
+    ]);
+
+    const reloaded = new CredentialStore(file);
+    expect(await reloaded.getCredential('anthropic')).toBe('sk-anthropic-concurrent');
+    expect(await reloaded.getCredential('openai')).toBe('sk-openai-concurrent');
   });
 });

--- a/apps/electron/src/main/credentialStore.ts
+++ b/apps/electron/src/main/credentialStore.ts
@@ -5,7 +5,7 @@
 // the renderer sends credentials in once and only ever receives metadata
 // (configured / updatedAt) back. All error paths redact secret material.
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { safeStorage } from 'electron';
 import type { CredentialInfo, CustomProviderConfig } from '@finagent/core';
@@ -25,7 +25,7 @@ interface CustomProviderRecord {
 
 interface StoreShape {
   version: 1;
-  credentials: Record<string, { encrypted: string }>;
+  credentials: Record<string, { encrypted: string; updatedAt?: number }>;
   customProviders: Record<string, CustomProviderRecord>;
 }
 
@@ -43,6 +43,7 @@ export function redactSecrets(message: string): string {
 export class CredentialStore {
   private readonly filePath: string;
   private cache: StoreShape | null = null;
+  private mutationQueue: Promise<void> = Promise.resolve();
 
   constructor(filePath: string) {
     this.filePath = filePath;
@@ -65,17 +66,18 @@ export class CredentialStore {
   }
 
   async setCredential(provider: string, apiKey: string): Promise<void> {
-    const store = await this.load();
-    store.credentials[provider] = {
-      encrypted: this.encrypt(apiKey),
-    };
-    await this.persist(store);
+    await this.mutate((store) => {
+      store.credentials[provider] = {
+        encrypted: this.encrypt(apiKey),
+        updatedAt: Date.now(),
+      };
+    });
   }
 
   async removeCredential(provider: string): Promise<void> {
-    const store = await this.load();
-    delete store.credentials[provider];
-    await this.persist(store);
+    await this.mutate((store) => {
+      delete store.credentials[provider];
+    });
   }
 
   /** Renderer-safe metadata: no secrets. */
@@ -85,7 +87,7 @@ export class CredentialStore {
       ([provider, entry]) => ({
         provider,
         configured: true,
-        updatedAt: this.readUpdatedAt(entry.encrypted),
+        updatedAt: entry.updatedAt,
         custom: false,
       })
     );
@@ -131,27 +133,29 @@ export class CredentialStore {
   }
 
   async setCustomProvider(config: CustomProviderConfig): Promise<void> {
-    const store = await this.load();
-    store.customProviders[config.name] = {
-      displayName: config.displayName,
-      baseUrl: config.baseUrl,
-      api: config.api ?? 'openai-completions',
-      models: config.models,
-      updatedAt: Date.now(),
-    };
-    if (config.apiKey !== undefined) {
-      store.credentials[`custom:${config.name}`] = {
-        encrypted: this.encrypt(config.apiKey),
+    await this.mutate((store) => {
+      const updatedAt = Date.now();
+      store.customProviders[config.name] = {
+        displayName: config.displayName,
+        baseUrl: config.baseUrl,
+        api: config.api ?? 'openai-completions',
+        models: config.models,
+        updatedAt,
       };
-    }
-    await this.persist(store);
+      if (config.apiKey !== undefined) {
+        store.credentials[`custom:${config.name}`] = {
+          encrypted: this.encrypt(config.apiKey),
+          updatedAt,
+        };
+      }
+    });
   }
 
   async removeCustomProvider(name: string): Promise<void> {
-    const store = await this.load();
-    delete store.customProviders[name];
-    delete store.credentials[`custom:${name}`];
-    await this.persist(store);
+    await this.mutate((store) => {
+      delete store.customProviders[name];
+      delete store.credentials[`custom:${name}`];
+    });
   }
 
   // -------------------------------------------------------------------------
@@ -175,26 +179,34 @@ export class CredentialStore {
   }
 
   private async persist(store: StoreShape): Promise<void> {
-    this.cache = store;
     await mkdir(dirname(this.filePath), { recursive: true });
-    // Atomic write: temp file + rename.
     const tempPath = `${this.filePath}.tmp`;
-    await writeFile(tempPath, JSON.stringify(store, null, 2), 'utf8');
-    await writeFile(this.filePath, JSON.stringify(store, null, 2), 'utf8');
     try {
-      await import('node:fs/promises').then(({ rename }) => rename(tempPath, this.filePath));
-    } catch {
-      // Fallback direct write above already landed; ignore rename errors.
+      await writeFile(tempPath, `${JSON.stringify(store, null, 2)}\n`, 'utf8');
+      await rename(tempPath, this.filePath);
+      this.cache = store;
+    } catch (error) {
+      await unlink(tempPath).catch(() => undefined);
+      throw error;
     }
+  }
+
+  /** Serialize mutations so concurrent credential updates cannot overwrite each other. */
+  private async mutate(update: (store: StoreShape) => void): Promise<void> {
+    const operation = this.mutationQueue.then(async () => {
+      const store = structuredClone(await this.load());
+      update(store);
+      await this.persist(store);
+    });
+    this.mutationQueue = operation.catch(() => undefined);
+    return operation;
   }
 
   private encrypt(plaintext: string): string {
     if (this.isEncryptionAvailable()) {
       return `v1:${safeStorage.encryptString(plaintext).toString('base64')}`;
     }
-    // No OS keychain available: keep plaintext off-disk surfaces out of reach
-    // is impossible; degrade to base64 obfuscation and mark the prefix.
-    return `plain:${Buffer.from(plaintext, 'utf8').toString('base64')}`;
+    throw new Error('Secure credential storage is unavailable on this system');
   }
 
   private decrypt(payload: string): string {
@@ -205,9 +217,4 @@ export class CredentialStore {
     return safeStorage.decryptString(Buffer.from(base64, 'base64'));
   }
 
-  private readUpdatedAt(encrypted: string): number | undefined {
-    // updatedAt is not stored per-credential in v1; return undefined.
-    void encrypted;
-    return undefined;
-  }
 }


### PR DESCRIPTION
## Summary

- fail closed instead of writing Base64-obfuscated credentials when Electron `safeStorage` is unavailable
- make credential writes truly atomic and surface persistence failures instead of silently falling back to a direct overwrite
- serialize credential mutations so concurrent updates cannot overwrite each other
- persist `updatedAt` metadata for provider credentials while remaining compatible with existing v1 stores and legacy `plain:` entries

## Why

The current fallback prefixes Base64 data with `plain:` even though the product and architecture documentation promise encryption at rest. The persistence path also writes the destination file directly before renaming the temporary file, which defeats the atomic-write guarantee and can expose a truncated credential store after interruption. Concurrent mutations share the same temporary path and can lose updates.

Legacy `plain:` values remain readable so existing users are not locked out, but new credentials are never persisted unless secure OS-backed encryption is available.

## Verification

- `bun test apps/electron/src/main/credentialStore.test.ts` — 8 passed
- `bun run typecheck` — passed for all workspaces
- `bun run build` — passed
- full suite: 1137 passed, 14 existing environment-dependent failures (missing gitignored LongBridge account fixtures/CLI plus unrelated Windows and locale-sensitive tests); no failure points to `CredentialStore`